### PR TITLE
Fix notecard box occasionally not fitting symmetrically into page

### DIFF
--- a/public_html/css/style.css
+++ b/public_html/css/style.css
@@ -100,7 +100,8 @@ a:hover {
 	padding: 5px 8px 5px 8px;
 	margin: 20px 8px 15px 8px;
 	background-color: #fff7ce;
-  width: 99%;
+	width: calc(100% - 20px);
+	box-sizing: border-box;
 }
 
 .not_moderated {


### PR DESCRIPTION
A minor CSS fix to prevent the notecard box used for the language info to be asymmetric, or occasionally even poking out of the parent page container. The `20px` referenced in the calculation refers to the `10px` padding on each side regularly used in the content parent container.